### PR TITLE
Update module providers block

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -47,7 +47,7 @@ func (a *SiteConfig) merge(c *GlobalConfig) {
 
 func (a *SiteConfig) providers() []string {
 	if a.Beta {
-		return []string{"provider = google-beta"}
+		return []string{"google = google-beta"}
 	}
-	return []string{"provider = google"}
+	return []string{"google = google"}
 }

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -32,11 +32,11 @@ func TestProviders(t *testing.T) {
 	config := SiteConfig{
 		Beta: false,
 	}
-	assert.Equal(t, []string{"provider = google"}, config.providers())
+	assert.Equal(t, []string{"google = google"}, config.providers())
 
 	// beta
 	config = SiteConfig{
 		Beta: true,
 	}
-	assert.Equal(t, []string{"provider = google-beta"}, config.providers())
+	assert.Equal(t, []string{"google = google-beta"}, config.providers())
 }


### PR DESCRIPTION
Currently the providers block within a module gets generated as

```hcl
module "blabla" {
	# ....
	providers = {
		provider = google/google-beta
	}
}
```

However this breaks the terraform init/plan/apply steps as it should be

```hcl
module "blabla" {
	# ....
	providers = {
		google = google/google-beta
	}
}
```