### PR TITLE
Feature/add locals with tags

### DIFF
--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestKey(t *testing.T) {
-
 	site := "my-site"
 	prefix := "my-prefix"
 
@@ -27,7 +26,6 @@ func TestKey(t *testing.T) {
 }
 
 func TestProviders(t *testing.T) {
-
 	// no beta
 	config := SiteConfig{
 		Beta: false,

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -172,15 +172,19 @@ func (p *Plugin) TerraformRenderResources(site string) (string, error) {
 	}
 
 	templateContext := struct {
-		Provider string
-		Project  string
-		Region   string
-		Zone     string
+		Provider    string
+		Project     string
+		Region      string
+		Zone        string
+		SiteName    string
+		Environment string
 	}{
-		Provider: provider,
-		Project:  cfg.Project,
-		Region:   cfg.Region,
-		Zone:     cfg.Zone,
+		Provider:    provider,
+		Project:     cfg.Project,
+		Region:      cfg.Region,
+		Zone:        cfg.Zone,
+		SiteName:    site,
+		Environment: p.environment,
 	}
 
 	template := `
@@ -188,6 +192,13 @@ func (p *Plugin) TerraformRenderResources(site string) (string, error) {
 			{{ renderProperty "project" .Project}}
 			{{ renderProperty "region" .Region}}
 			{{ renderProperty "zone" .Zone}}
+		}
+
+		locals {
+			tags = {
+				Site = "{{ .SiteName }}"
+				Environment = "{{ .Environment }}"
+			}
 		}
 	`
 	return helpers.RenderGoTemplate(template, templateContext)

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -121,3 +121,27 @@ func TestRenderTerraformProviders(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result, "version = \"~> 0.0.1\"")
 }
+
+func TestTerraformRenderResources(t *testing.T) {
+	plugin := NewGcpPlugin()
+	err := plugin.Configure("dev", "0.0.1")
+	require.NoError(t, err)
+
+	err = plugin.SetGlobalConfig(map[string]any{
+		"project": "0123456789",
+		"region":  "us-central1",
+		"zone":    "us-central1-a",
+	})
+	require.NoError(t, err)
+
+	err = plugin.SetSiteConfig("my-site", map[string]any{})
+	require.NoError(t, err)
+
+	result, err := plugin.RenderTerraformResources("my-site")
+	require.NoError(t, err)
+	assert.Contains(t, result, "locals {")
+	assert.Contains(t, result, "\ttags = {")
+	assert.Contains(t, result, "\t\tSite = \"my-site\"")
+	assert.Contains(t, result, "\t\tEnvironment = \"dev\"")
+	assert.Contains(t, result, "\t}")
+}


### PR DESCRIPTION
Currently the plugin fails since ``mach-composer`` expects a ``locals { tags = {} }`` which wasn't set before. 

For this integration I've created the default tags ``Site`` and ``Environment`` which is also done by the ``mach-composer-plugin-aws``